### PR TITLE
Use Python's version info directly instead of parsing human-readable …

### DIFF
--- a/support/dependencies/check-host-python3.sh
+++ b/support/dependencies/check-host-python3.sh
@@ -18,7 +18,7 @@ for candidate in "${@}" ; do
 	if [ ! -x "$python3" ]; then
 		continue
 	fi
-	version=`$python3 -V 2>&1 | awk '{ split($2, v, "."); print v[1] v[2] }'`
+	version=$($python3 -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
 
 	if [ $version -lt $version_min ]; then
 		# no suitable python3 found


### PR DESCRIPTION
…version

Parsing `-V` is brittle and this breaks on my machine. Instead, use `sys.version_info` from within Python to get access to the desired format.